### PR TITLE
Add check for integers in count_mat

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1641,6 +1641,12 @@ check_matrix = function(count_mat) {
     if (!('dgCMatrix' %in% class(count_mat))) {
         log_err("count_mat is not of class dgCMatrix or matrix")
     }
+    if (!is.numeric(count_mat@x)) {
+        log_err("The parameter 'count_mat' in the function check_matrix() must be of type 'integer'. Please fix.")
+    }
+    if (all(count_mat@x != as.integer(count_mat@x))) {
+        log_err("The parameter 'count_mat' in the function check_matrix() must be of type 'integer'. Please fix.")
+    }
     if (any(duplicated(rownames(count_mat)))) {
         log_err("Please remove duplicated genes in count matrix")
     }


### PR DESCRIPTION
Related to this PR: https://github.com/kharchenkolab/numbat/pull/38

CC @igordot 

We were having a discussion in that PR about how to best proceed on this PR. 

Here's how I would handle this. Let me know what you think. 


Here's how to test:

```
library(logger)
library(Matrix)

log_err = function(msg) {
    log_error(msg)
    stop(msg)
}


ex1 <- matrix(c(3:14), nrow = 4, byrow = TRUE)
ex2 <- Matrix(c(0,0,2:0), 3,5)
fail_ex <-matrix(c(2.3, 3.4, 3.2, 1.1, 1.1, 5.5, 5.5, 6.5, 8.7), nrow = 3, byrow = TRUE) ## should fail

check_matrix = function(count_mat) {
    if ('matrix' %in% class(count_mat)) {
        count_mat <- as(Matrix(count_mat, sparse=TRUE), "dgCMatrix")
    }
    if (!('dgCMatrix' %in% class(count_mat))) {
        log_err("count_mat is not of class dgCMatrix or matrix")
    }
    if (!is.numeric(count_mat@x)) {
        log_err("The parameter 'count_mat' in the function check_matrix() must be of type 'integer'. Please fix.")
    }
    if (all(count_mat@x != as.integer(count_mat@x))) {
        log_err("The parameter 'count_mat' in the function check_matrix() must be of type 'integer'. Please fix.")
    }
    if (any(duplicated(rownames(count_mat)))) {
        log_err("Please remove duplicated genes in count matrix")
    }
    return(count_mat)
}


check_matrix(ex1)
check_matrix(ex2)
## should fail
check_matrix(fail_ex)
```



