### PR TITLE
toggle phylogeny in plot_phylo_heatmap

### DIFF
--- a/R/vis.R
+++ b/R/vis.R
@@ -5,21 +5,21 @@ pal = c("#E41A1C", "#377EB8", "#4DAF4A", "#984EA3", "#FF7F00", "#FFFF33", "#A656
 getPalette = colorRampPalette(pal)
 
 #' @keywords internal
-cnv_colors = c("neu" = "gray", 
+cnv_colors = c("neu" = "gray",
         "neu_up" = "darkgray", "neu_down" = "gray",
-        "del_up" = "royalblue", "del_down" = "darkblue", 
+        "del_up" = "royalblue", "del_down" = "darkblue",
         "loh_up" = "darkgreen", "loh_down" = "olivedrab4",
         "amp_up" = "red", "amp_down" = "tomato3",
-        "del_1_up" = "royalblue", "del_1_down" = "darkblue", 
+        "del_1_up" = "royalblue", "del_1_down" = "darkblue",
         "loh_1_up" = "darkgreen", "loh_1_down" = "olivedrab4",
         "amp_1_up" = "red", "amp_1_down" = "tomato3",
-        "del_2_up" = "royalblue", "del_2_down" = "darkblue", 
+        "del_2_up" = "royalblue", "del_2_down" = "darkblue",
         "loh_2_up" = "darkgreen", "loh_2_down" = "olivedrab4",
         "amp_2_up" = "red", "amp_2_down" = "tomato3",
-        "del_up_1" = "royalblue", "del_down_1" = "darkblue", 
+        "del_up_1" = "royalblue", "del_down_1" = "darkblue",
         "loh_up_1" = "darkgreen", "loh_down_1" = "olivedrab4",
         "amp_up_1" = "red", "amp_down_1" = "tomato3",
-        "del_up_2" = "royalblue", "del_down_2" = "darkblue", 
+        "del_up_2" = "royalblue", "del_down_2" = "darkblue",
         "loh_up_2" = "darkgreen", "loh_down_2" = "olivedrab4",
         "amp_up_2" = "red", "amp_down_2" = "tomato3",
         "bamp" = "salmon", "bdel" = "skyblue",
@@ -33,7 +33,7 @@ cnv_colors = c("neu" = "gray",
 
 #' @keywords internal
 cnv_labels = names(cnv_colors) %>%
-    stringr::str_remove_all('_') %>% 
+    stringr::str_remove_all('_') %>%
     stringr::str_to_upper() %>%
     stringr::str_replace('UP', '(major)') %>%
     stringr::str_replace('DOWN', '(minor)') %>%
@@ -62,8 +62,8 @@ cnv_labels = names(cnv_colors) %>%
 #' p = plot_psbulk(bulk_example)
 #' @export
 plot_psbulk = function(
-        bulk, use_pos = TRUE, allele_only = FALSE, min_LLR = 5, min_depth = 8, exp_limit = 2, 
-        phi_mle = TRUE, theta_roll = FALSE, dot_size = 0.8, dot_alpha = 0.5, legend = FALSE, 
+        bulk, use_pos = TRUE, allele_only = FALSE, min_LLR = 5, min_depth = 8, exp_limit = 2,
+        phi_mle = TRUE, theta_roll = FALSE, dot_size = 0.8, dot_alpha = 0.5, legend = FALSE,
         exclude_gap = TRUE, genome = 'hg38', raster = FALSE
     ) {
 
@@ -97,8 +97,8 @@ plot_psbulk = function(
         marker_label = 'SNP index'
     }
 
-    # fix retest states 
-    bulk = bulk %>% 
+    # fix retest states
+    bulk = bulk %>%
         mutate(
             theta_level = ifelse(str_detect(state_post, '_2'), 2, 1),
             state_post = ifelse(
@@ -112,7 +112,7 @@ plot_psbulk = function(
         bulk = bulk %>% mutate(logFC = logFC - mu)
     }
 
-    D = bulk %>% 
+    D = bulk %>%
         mutate(logFC = ifelse(logFC > exp_limit | logFC < -exp_limit, NA, logFC)) %>%
         mutate(pBAF = ifelse(DP >= min_depth, pBAF, NA)) %>%
         mutate(pHF = pBAF) %>%
@@ -139,16 +139,16 @@ plot_psbulk = function(
         } else {
             stop("Genome version must be hg38 or hg19")
         }
-        
-        segs_exclude = gaps %>% 
-            filter(end - start > 1e+06) %>% 
+
+        segs_exclude = gaps %>%
+            filter(end - start > 1e+06) %>%
             rbind(acen) %>%
             rename(seg_start = start, seg_end = end) %>%
             filter(CHROM %in% bulk$CHROM)
 
         if (nrow(segs_exclude) > 0) {
-            p = p + geom_rect(inherit.aes = FALSE, data = segs_exclude, 
-                aes(xmin = seg_start, xmax = seg_end, ymin = -Inf, ymax = Inf), 
+            p = p + geom_rect(inherit.aes = FALSE, data = segs_exclude,
+                aes(xmin = seg_start, xmax = seg_end, ymin = -Inf, ymax = Inf),
                 fill = "gray95")
         }
     }
@@ -198,7 +198,7 @@ plot_psbulk = function(
     }
 
     if (phi_mle & (!allele_only)) {
-        segs = bulk %>% 
+        segs = bulk %>%
             distinct(CHROM, seg, seg_start, seg_start_index, seg_end, seg_end_index, phi_mle) %>%
             mutate(variable = 'logFC') %>%
             filter(log2(phi_mle) < exp_limit)
@@ -231,7 +231,7 @@ plot_psbulk = function(
     }
 
     if (theta_roll) {
-        p = p + 
+        p = p +
             geom_line(
                 inherit.aes = FALSE,
                 data = D %>% mutate(variable = 'pHF'),
@@ -246,19 +246,19 @@ plot_psbulk = function(
                 # color = 'gray',
                 size = 0.35
             )
-    } 
+    }
 
     p = p + xlab(marker_label)
 
     if (raster) {
         p = ggrastr::rasterize(p, layers = 'Point', dpi = 300)
     }
-    
+
     return(p)
 }
 
 #' Plot a group of pseudobulk HMM profiles
-#' 
+#'
 #' @param bulks dataframe Pseudobulk profiles annotated with "sample" column
 #' @param ncol integer Number of columns
 #' @param title logical Whether to add titles to individual plots
@@ -285,7 +285,7 @@ plot_bulks = function(
 
                 p = plot_psbulk(
                         bulk, ...
-                    ) + 
+                    ) +
                     theme(
                         title = element_text(size = 8),
                         axis.text.x = element_blank(),
@@ -300,7 +300,7 @@ plot_bulks = function(
                     }
                     p = p + ggtitle(title_text)
                 }
-                    
+
                 return(p)
             }
         )
@@ -320,7 +320,7 @@ plot_bulks = function(
 #' @param arrow_size numeric Size of arrows
 #' @param edge_label logical Whether to label edges
 #' @param node_label logical Whether to label nodes
-#' @param horizontal logical Whether to use horizontal layout 
+#' @param horizontal logical Whether to use horizontal layout
 #' @param show_clone_size logical Whether to show clone size
 #' @param show_distance logical Whether to show evolutionary distance between clones
 #' @param legend logical Whether to show legend
@@ -330,7 +330,7 @@ plot_bulks = function(
 #' p = plot_mut_history(mut_graph_example)
 #' @export
 plot_mut_history = function(
-        G, clone_post = NULL, 
+        G, clone_post = NULL,
         edge_label_size = 4, node_label_size = 6, node_size = 10, arrow_size = 2,
         show_clone_size = TRUE, show_distance = TRUE, legend = TRUE,
         edge_label = TRUE, node_label = TRUE, horizontal = TRUE, pal = NULL
@@ -354,8 +354,8 @@ plot_mut_history = function(
         pal = c('gray', getPalette(length(V(G))))
     }
 
-    G_df = G %>% as_tbl_graph() %>% mutate(clone = factor(clone)) 
-    
+    G_df = G %>% as_tbl_graph() %>% mutate(clone = factor(clone))
+
     if (!'superclone' %in% colnames(as.data.frame(activate(G_df, 'nodes')))) {
         G_df = G_df %>% mutate(superclone = clone)
     }
@@ -377,11 +377,11 @@ plot_mut_history = function(
         G_df = G_df %>% activate(edges) %>% mutate(to_label = '')
     }
 
-    p = G_df %>% 
+    p = G_df %>%
         ggraph(
             layout = 'dendrogram',
             length = length
-        ) + 
+        ) +
         geom_edge_elbow(
             aes(label = str_trunc(to_label, 20, side = 'center')),
             vjust = -1,
@@ -390,7 +390,7 @@ plot_mut_history = function(
             end_cap = circle(4, 'mm'),
             start_cap = circle(4, 'mm'),
             label_size = edge_label_size
-        ) + 
+        ) +
         theme_void() +
         scale_x_continuous(expand = expansion(0.2)) +
         scale_color_manual(values = pal, limits = force) +
@@ -405,7 +405,7 @@ plot_mut_history = function(
     if (show_clone_size) {
         p = p + geom_node_point(
                 aes(color = as.factor(superclone), size = size)
-            ) + 
+            ) +
             scale_size_continuous(
                 range = c(0, node_size),
                 limits = c(0, size_max),
@@ -423,7 +423,7 @@ plot_mut_history = function(
             p = p + geom_node_text(aes(label = clone, size = size/2))
         } else {
             p = p + geom_node_text(aes(label = clone), size = node_label_size)
-        }        
+        }
     }
 
     if (horizontal) {
@@ -442,8 +442,8 @@ plot_mut_history = function(
 #' @param segs_consensus datatframe Consensus segment dataframe
 #' @param annot named vector Cell annotations, keys are cell names
 #' @param pal_annot named vector Colors for cell annotations
-#' @param annot_title character Legend title for the annotation bar 
-#' @param annot_scale ggplot scale Color scale for the annotation bar 
+#' @param annot_title character Legend title for the annotation bar
+#' @param annot_scale ggplot scale Color scale for the annotation bar
 #' @param clone_dict named vector Clone annotations, mapping from cell name to clones
 #' @param clone_bar logical Whether to display clone bar plot
 #' @param clone_title character Legend title for the clone bar
@@ -459,21 +459,22 @@ plot_mut_history = function(
 #' @param root_edge logical Whether to plot root edge
 #' @param exclude_gap logical Whether to mark gap regions
 #' @param raster logical Whether to raster images
+#' @param show_phylo logical Whether to display phylogeny on y axis
 #' @return ggplot panel
 #' @examples
 #' p = plot_phylo_heatmap(
-#'     gtree = phylogeny_example, 
-#'     joint_post = joint_post_example, 
+#'     gtree = phylogeny_example,
+#'     joint_post = joint_post_example,
 #'     segs_consensus = segs_example)
 #' @export
 plot_phylo_heatmap = function(
-        gtree, joint_post, segs_consensus, 
+        gtree, joint_post, segs_consensus,
         annot = NULL, pal_annot = NULL, annot_title = 'Annotation', annot_scale = NULL,
-        clone_dict = NULL, clone_bar = FALSE, pal_clone = NULL, clone_title = 'Genotype', clone_legend = TRUE, 
-        p_min = 0.9, line_width = 0.1, tree_height = 1, branch_width = 0.2, tip_length = 0.2, 
-        clone_line = FALSE, superclone = FALSE, exclude_gap = FALSE, root_edge = TRUE, raster = FALSE
+        clone_dict = NULL, clone_bar = FALSE, pal_clone = NULL, clone_title = 'Genotype', clone_legend = TRUE,
+        p_min = 0.9, line_width = 0.1, tree_height = 1, branch_width = 0.2, tip_length = 0.2,
+        clone_line = FALSE, superclone = FALSE, exclude_gap = FALSE, root_edge = TRUE, raster = FALSE, show_phylo = TRUE
     ) {
-    
+
     # make sure chromosomes are in order
     joint_post = joint_post %>% mutate(CHROM = as.integer(as.character(CHROM)))
     segs_consensus = segs_consensus %>% mutate(CHROM = as.integer(as.character(CHROM)))
@@ -481,12 +482,12 @@ plot_phylo_heatmap = function(
     # if no multi allelic CNVs
     if (!'n_states' %in% colnames(joint_post)) {
         joint_post = joint_post %>% mutate(
-            n_states = ifelse(cnv_state == 'neu', 1, 0), 
+            n_states = ifelse(cnv_state == 'neu', 1, 0),
             cnv_states = cnv_state
         )
     } else {
         # only keep one record per CNV and color by most likely state
-        joint_post = joint_post %>% 
+        joint_post = joint_post %>%
             group_by(cell, CHROM, seg_end, seg_start) %>%
             mutate(p_cnv = sum(p_cnv)) %>%
             ungroup() %>%
@@ -508,39 +509,49 @@ plot_phylo_heatmap = function(
 
     gtree = gtree %>% activate(edges) %>% mutate(length = ifelse(leaf, tip_length, length))
 
-    # plot phylogeny 
-    p_tree = gtree %>% 
-        to_phylo() %>%
-        ggtree::ggtree(ladderize = TRUE, size = branch_width) +
-        theme(
-            plot.margin = margin(0,1,0,0, unit = 'mm'),
-            axis.title.x = element_blank(),
-            axis.ticks.x = element_blank(),
-            axis.text.x = element_blank(),
-            axis.line.y = element_blank(),
-            axis.ticks.y = element_blank(),
-            # axis.text.y = element_text(size = 5)
-            axis.text.y = element_blank(),
-            panel.background = element_rect(fill = "transparent",colour = NA),
-            plot.background = element_rect(fill = "transparent", color = NA)
-        ) +
-        guides(color = 'none')
+    # plot phylogeny
+    if (show_phylo){
+    	p_tree = gtree %>%
+    		to_phylo() %>%
+    		ggtree::ggtree(ladderize = TRUE, size = branch_width) +
+    		theme(
+    			plot.margin = margin(0,1,0,0, unit = 'mm'),
+    			axis.title.x = element_blank(),
+    			axis.ticks.x = element_blank(),
+    			axis.text.x = element_blank(),
+    			axis.line.y = element_blank(),
+    			axis.ticks.y = element_blank(),
+    			# axis.text.y = element_text(size = 5)
+    			axis.text.y = element_blank(),
+    			panel.background = element_rect(fill = "transparent",colour = NA),
+    			plot.background = element_rect(fill = "transparent", color = NA)
+    		) +
+    		guides(color = 'none')
 
-    if (root_edge) {
-        p_tree = p_tree + ggtree::geom_rootedge(size = branch_width)
+    	if (root_edge) {
+    		p_tree = p_tree + ggtree::geom_rootedge(size = branch_width)
+    	}
+
+    	# order the cells
+    	cell_order = p_tree$data %>% filter(isTip) %>% arrange(y) %>% pull(label)
+    } else {
+    	p_tree = gtree %>%
+    		treeio::as.phylo() %>%
+    		ape::ladderize(right = FALSE)
+
+    	cell_order = rev(p_tree$tip.label)
+
+    	p_tree = ggplot() + theme_void()
     }
 
-    # order the cells
-    cell_order = p_tree$data %>% filter(isTip) %>% arrange(y) %>% pull(label)
-
-    joint_post = joint_post %>% 
+    joint_post = joint_post %>%
         mutate(cell = factor(cell, cell_order)) %>%
-        mutate(cell_index = as.integer(droplevels(cell))) 
+        mutate(cell_index = as.integer(droplevels(cell)))
 
     # add tumor vs normal line
-    tumor_cells = gtree %>% 
+    tumor_cells = gtree %>%
         activate(nodes) %>% filter(leaf) %>%
-        as.data.frame() %>% 
+        as.data.frame() %>%
         filter(compartment == 'tumor') %>%
         pull(name)
 
@@ -559,7 +570,7 @@ plot_phylo_heatmap = function(
         ) +
         geom_blank() +
         theme_classic()
-        
+
     p_segs = p_segs +
         geom_segment(
             aes(x = seg_start, xend = seg_end, y = cell_index, yend = cell_index, color = cnv_state, alpha = p_cnv),
@@ -605,16 +616,16 @@ plot_phylo_heatmap = function(
 
     if (exclude_gap) {
 
-        segs_exclude = gaps_hg38 %>% 
-            filter(end - start > 1e+06) %>% 
+        segs_exclude = gaps_hg38 %>%
+            filter(end - start > 1e+06) %>%
             # bind_rows(acen_hg38) %>%
             rename(seg_start = start, seg_end = end) %>%
             mutate(CHROM = as.integer(CHROM))
 
-        p_segs = p_segs + 
+        p_segs = p_segs +
             geom_rect(
                 inherit.aes = FALSE,
-                data = segs_exclude, 
+                data = segs_exclude,
                 aes(xmin = seg_start,
                     xmax = seg_end,
                     ymin = -Inf,
@@ -647,7 +658,7 @@ plot_phylo_heatmap = function(
         if ('1' %in% unique(clone_dict)) {
             pal_clone = c('gray', pal_clone)
         }
-        
+
     }
 
     p_clone = data.frame(
@@ -657,12 +668,12 @@ plot_phylo_heatmap = function(
         mutate(cell = factor(cell, cell_order)) %>%
         filter(!is.na(cell)) %>%
         annot_bar(transpose = TRUE, legend = clone_legend, pal_annot = pal_clone, legend_title = clone_title, size = size, raster = raster)
-    
+
     # add clone lines
     if (clone_line) {
 
-        leafs = gtree %>% 
-                activate(nodes) %>% 
+        leafs = gtree %>%
+                activate(nodes) %>%
                 filter(leaf) %>%
                 as.data.frame()
 
@@ -671,14 +682,14 @@ plot_phylo_heatmap = function(
 
         clone_indices = sapply(
             clones,
-            function(c) {                
-                
+            function(c) {
+
                 clone_cells = leafs %>% filter(clone == c) %>% pull(name)
-                
+
                 first_clone_index = which(cell_order %in% clone_cells)[1]
 
                 return(first_clone_index)
-                
+
             }
         )
 
@@ -691,7 +702,7 @@ plot_phylo_heatmap = function(
 
     # external annotation
     if (!is.null(annot)) {
-        
+
         p_annot = data.frame(
                 cell = names(annot),
                 annot = unname(annot)
@@ -714,19 +725,19 @@ plot_phylo_heatmap = function(
 
 
 #' Plot consensus CNVs
-#' 
+#'
 #' @param segs dataframe Consensus segments
 #' @return ggplot object
 #' @examples
 #' p = plot_consensus(segs_example)
 #' @export
 plot_consensus = function(segs) {
-  
+
     chrom_labeller <- function(chr){
         chr[chr %in% c(19, 21, 22)] = ''
         return(chr)
     }
-    
+
     ggplot(
         segs
     ) +
@@ -751,7 +762,7 @@ plot_consensus = function(segs) {
         aes(x = (seg_start+seg_end)/2, y = -0.5,
             label = str_remove(seg_cons, '\\d+')),
         min.segment.length = 0,
-        vjust = 1, 
+        vjust = 1,
         hjust = 0,
         direction = 'x',
         segment.curvature = -0.2,
@@ -770,7 +781,7 @@ plot_consensus = function(segs) {
 }
 
 #' Plot single-cell smoothed expression magnitude heatmap
-#' 
+#'
 #' @param gexp_roll_wide matrix Cell x gene smoothed expression magnitudes
 #' @param hc hclust Hierarchical clustring result
 #' @param gtf dataframe Transcript GTF
@@ -785,7 +796,7 @@ plot_consensus = function(segs) {
 #' @export
 plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, reverse = TRUE, plot_tree = TRUE) {
 
-    gexp_norm_long = gexp_roll_wide %>% 
+    gexp_norm_long = gexp_roll_wide %>%
         as.data.frame() %>%
         tibble::rownames_to_column('cell') %>%
         reshape2::melt(id.var = 'cell', variable.name = 'gene', value.name = 'exp_rollmean') %>%
@@ -794,9 +805,9 @@ plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, 
         mutate(gene_index = as.integer(factor(gene, unique(gene))))
 
     cells = unique(gexp_norm_long$cell)
-    
+
     cell_sample = sample(cells, min(n_sample, length(cells)), replace = FALSE)
-        
+
     p_tree = ggtree::ggtree(hc, size = 0.2)
 
     cell_order = p_tree$data %>% filter(isTip) %>% arrange(y) %>% pull(label)
@@ -805,7 +816,7 @@ plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, 
         chr[chr %in% c(18, 21)] = ''
         return(chr)
     }
-    
+
     p_heatmap = gexp_norm_long %>%
         filter(cell %in% cell_sample) %>%
         mutate(cell = factor(cell, cell_order)) %>%
@@ -833,7 +844,7 @@ plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, 
         guides(fill = guide_colorbar(title = 'Expression\nmagnitude')) +
         xlab('Gene index') +
         ylab('Cell')
-    
+
     if (plot_tree) {
         (p_tree | p_heatmap) + plot_layout(widths = c(1,10))
     } else {
@@ -842,7 +853,7 @@ plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, 
 }
 
 #' Plot single-cell smoothed expression magnitude heatmap
-#' 
+#'
 #' @param gtree tbl_graph The single-cell phylogeny
 #' @param label_mut logical Whether to label mutations
 #' @param label_size numeric Size of mutation labels
@@ -852,7 +863,7 @@ plot_exp_roll = function(gexp_roll_wide, hc, k, gtf, lim = 0.8, n_sample = 300, 
 #' @param tip_length numeric Length of the tips
 #' @param pal_clone named vector Clone colors
 #' @return ggplot A single-cell phylogeny with mutation history labeled
-#' @examples 
+#' @examples
 #' p = plot_sc_tree(phylogeny_example)
 #' @export
 plot_sc_tree = function(gtree, label_mut = TRUE, label_size = 3, dot_size = 2, branch_width = 0.5, tip = TRUE, tip_length = 0.5, pal_clone = NULL) {
@@ -860,9 +871,9 @@ plot_sc_tree = function(gtree, label_mut = TRUE, label_size = 3, dot_size = 2, b
     mut_nodes = gtree %>% activate(nodes) %>%
       filter(!is.na(site)) %>% data.frame() %>%
       select(name, site)
-    
+
     gtree = gtree %>% activate(edges) %>% mutate(length = ifelse(leaf, pmax(length, tip_length), length))
-    
+
     clone_dict = gtree %>%
         activate(nodes) %>%
         data.frame %>%
@@ -872,10 +883,10 @@ plot_sc_tree = function(gtree, label_mut = TRUE, label_size = 3, dot_size = 2, b
             clone = as.factor(clone)
         ) %>%
       {setNames(.$clone, .$name)}
-    
+
     OTU_dict = lapply(levels(clone_dict), function(x) names(clone_dict[clone_dict == x])) %>% setNames(levels(clone_dict))
 
-    p_tree = gtree %>% 
+    p_tree = gtree %>%
         to_phylo() %>%
         ggtree::groupOTU(
             OTU_dict,
@@ -898,7 +909,7 @@ plot_sc_tree = function(gtree, label_mut = TRUE, label_size = 3, dot_size = 2, b
         xlab('Number of mutations')
 
     if (label_mut) {
-        p_tree = p_tree + 
+        p_tree = p_tree +
             ggtree::geom_point2(aes(subset = !is.na(site), x = branch), shape = 21, size = dot_size, fill = 'red') +
             ggtree::geom_text2(
                 aes(x = branch, label = str_trunc(site, 20, side = 'center')),
@@ -914,13 +925,13 @@ plot_sc_tree = function(gtree, label_mut = TRUE, label_size = 3, dot_size = 2, b
             pal_clone = getPalette(nrow(mut_nodes) + 1)
         }
 
-        p_tree = p_tree + 
+        p_tree = p_tree +
             ggtree::geom_tippoint(aes(color = as.factor(clone)), size=dot_size, stroke = 0.2) +
             scale_color_manual(values = pal_clone, limits = force)
     }
-    
+
     return(p_tree)
-    
+
 }
 
 #' Plot CNV heatmap
@@ -950,7 +961,7 @@ cnv_heatmap = function(segs, var = 'group', label_group = TRUE, legend = TRUE, e
     } else {
         stop("Genome version must be hg38 or hg19")
     }
-    
+
     p = ggplot(
             segs
         ) +
@@ -964,15 +975,15 @@ cnv_heatmap = function(segs, var = 'group', label_group = TRUE, legend = TRUE, e
 
     if (exclude_gap) {
 
-        segs_exclude = gaps %>% 
-            filter(end - start > 1e+06) %>% 
-            rename(seg_start = start, seg_end = end) 
+        segs_exclude = gaps %>%
+            filter(end - start > 1e+06) %>%
+            rename(seg_start = start, seg_end = end)
 
         p = p +
             geom_rect(
                 inherit.aes = FALSE,
                 data = segs_exclude,
-                aes(xmin = seg_start, 
+                aes(xmin = seg_start,
                     xmax = seg_end,
                     ymin = -Inf,
                     ymax = Inf),
@@ -981,7 +992,7 @@ cnv_heatmap = function(segs, var = 'group', label_group = TRUE, legend = TRUE, e
             geom_rect(
                 inherit.aes = FALSE,
                 data = segs_exclude,
-                aes(xmin = seg_start, 
+                aes(xmin = seg_start,
                     xmax = seg_end,
                     ymin = -Inf,
                     ymax = Inf),
@@ -989,7 +1000,7 @@ cnv_heatmap = function(segs, var = 'group', label_group = TRUE, legend = TRUE, e
                 alpha = 0.5
             )
     }
-        
+
     p = p +
         theme_classic() +
         theme(
@@ -1104,7 +1115,7 @@ oob_squish <- function(x, range = c(0, 1), only.finite = TRUE) {
 #' @keywords internal
 show_phasing = function(bulk, min_depth = 8, dot_size = 0.5, h = 50) {
 
-    D = bulk %>% 
+    D = bulk %>%
         filter(!is.na(pAD)) %>%
         group_by(CHROM) %>%
         mutate(pBAF = 1-pBAF, pAD = DP - pAD) %>%
@@ -1116,7 +1127,7 @@ show_phasing = function(bulk, min_depth = 8, dot_size = 0.5, h = 50) {
         mutate(dAR_roll = caTools::runmean(abs(AR-0.5), align = 'center', k = 30))
 
     boundary = D %>% filter(boundary == 1) %>% pull(snp_index)
-    
+
     p1 = D %>%
         mutate(state_post = 'neu') %>%
         ggplot(
@@ -1211,12 +1222,12 @@ plot_exp_post = function(exp_post, jitter = TRUE) {
 
 #' @keywords internal
 plot_clone_profile = function(joint_post, clone_post) {
-    
+
     clone_profile = get_clone_profile(joint_post, clone_post)
-    
+
     p_heatmap = clone_profile %>% cnv_heatmap(var = 'clone', label_group = FALSE)
-    
-    p_bubble = clone_profile %>% 
+
+    p_bubble = clone_profile %>%
         ggplot(
             aes(x = 0, y = clone, size = size)
         ) +
@@ -1231,8 +1242,8 @@ plot_clone_profile = function(joint_post, clone_post) {
             range = c(0, 5),
             name = 'Cells'
         )
-    
+
     panel = (p_bubble | p_heatmap) + plot_layout(widths = c(0.5,20))
-    
+
     return(panel)
 }

--- a/man/plot_phylo_heatmap.Rd
+++ b/man/plot_phylo_heatmap.Rd
@@ -26,7 +26,8 @@ plot_phylo_heatmap(
   superclone = FALSE,
   exclude_gap = FALSE,
   root_edge = TRUE,
-  raster = FALSE
+  raster = FALSE,
+  show_phylo = TRUE
 )
 }
 \arguments{
@@ -73,6 +74,8 @@ plot_phylo_heatmap(
 \item{root_edge}{logical Whether to plot root edge}
 
 \item{raster}{logical Whether to raster images}
+
+\item{show_phylo}{logical Whether to display phylogeny on y axis}
 }
 \value{
 ggplot panel
@@ -82,7 +85,7 @@ Plot single-cell CNV calls along with the clonal phylogeny
 }
 \examples{
 p = plot_phylo_heatmap(
-    gtree = phylogeny_example, 
-    joint_post = joint_post_example, 
+    gtree = phylogeny_example,
+    joint_post = joint_post_example,
     segs_consensus = segs_example)
 }


### PR DESCRIPTION
I added an argument `show_phylo` to toggle plotting and display of the single cell phylogeny in the `plot_phylo_heatmap` function. There are additional diffs due to whitespace changes (sorry about that) this is to avoid memory usage and plotting time with deep trees 

https://github.com/kharchenkolab/numbat/issues/30